### PR TITLE
Move delta

### DIFF
--- a/scripts/codeEditor.js
+++ b/scripts/codeEditor.js
@@ -176,9 +176,9 @@ function CodeEditor(textAreaDomID, width, height) {
 			// modify editable sections accordingly
 			if (editableSections[change.to.line]) {
 				var sections = editableSections[change.to.line];
+					var delta = change.text[0].length - (change.to.ch - change.from.ch);
 				for (var i = 0; i < sections.length; i++) {
 					// move any section start/end points that we are to the left of
-					var delta = change.text[0].length - (change.to.ch - change.from.ch);
 					if (change.to.ch < sections[i][1]) {
 						sections[i][1] += delta;
 					}


### PR DESCRIPTION
`delta` can be moved out of the loop, can't it?

``` js
            // modify editable sections accordingly
            if (editableSections[change.to.line]) {
                var sections = editableSections[change.to.line];
                for (var i = 0; i < sections.length; i++) {
                    // move any section start/end points that we are to the left of
                    var delta = change.text[0].length - (change.to.ch - change.from.ch);
                    if (change.to.ch < sections[i][1]) {
                        sections[i][1] += delta;
                    }
                    if (change.to.ch < sections[i][0]) {
                        sections[i][0] += delta;
                    }
                }
            }
```
