### PR TITLE
Fix off-by-one bug with endOfStartLevel replace.

### DIFF
--- a/scripts/codeEditor.js
+++ b/scripts/codeEditor.js
@@ -392,7 +392,7 @@ function CodeEditor(textAreaDomID, width, height, game) {
 
         if (!forSaving && endOfStartLevel) {
             // insert the end of startLevel() marker at the appropriate location
-            lines.splice(endOfStartLevel, 0, "map._endOfStartLevelReached()");
+            lines.splice(endOfStartLevel+1, 0, "map._endOfStartLevelReached()");
         }
 
         return lines.join('\n');


### PR DESCRIPTION
This was causing failures on levels 14 and 17. Verified the fix with a local browser JS change. Tried to load a couple of other levels to make sure I didn't break anything else. The issue here is that inserting startOfStartLevel increases the number of lines in the array.
