### PR TITLE
prevent bypassing validation using base64

### DIFF
--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -10,7 +10,8 @@ Game.prototype.verbotenWords = [
     'prompt', 'confirm', // prevents dialogs asking for user input
     'debugger', // prevents pausing execution
     'delete', // prevents removing items
-    'atob','btoa',//prevent bypassing checks using Base64
+    'atob(','btoa(',//prevent bypassing checks using Base64
+    'Function(', //prevent constructing arbitrary function
     'window', // prevents setting "window.[...] = map", etc.
     'document', // in particular, document.write is dangerous
     'self.', 'self[', 'top.', 'top[', 'frames',  // self === top === frames === window


### PR DESCRIPTION
Currently the underscore validation can be easily bypassed with base64 
