### PR TITLE
map.getAdjacentEmptyCells:  We need to check, if child is inside of map!

### DIFF
--- a/scripts/map.js
+++ b/scripts/map.js
@@ -474,7 +474,11 @@ function Map(display, __game) {
     this.getObjectTypeAt = wrapExposedMethod(function (x, y) {
         var x = Math.floor(x); var y = Math.floor(y);
 
-        return __grid[x][y].type;
+        // Bazek: We should always check, if the coordinates are inside of map!
+        if (x >= 0 && x < this.getWidth() && y >= 0 && y < this.getHeight())
+            return __grid[x][y].type;
+        else
+            return '';
     }, this);
 
     this.getAdjacentEmptyCells = wrapExposedMethod(function (x, y) {


### PR DESCRIPTION
My algorithm explored all the map cells and found the shortest path from robot to player.
Problem was the border cells (outside the labyrinth) for which this function failed and the agrorithm was stopped.
