### PR TITLE
Dynamic objects cannot be impassable.

### DIFF
--- a/scripts/reference.js
+++ b/scripts/reference.js
@@ -355,7 +355,7 @@ Game.prototype.reference = {
         'name': 'object.impassable = function (player, object)',
         'category': 'object',
         'type': 'property',
-        'description': 'The function that determines whether or not the player can pass through this object.'
+        'description': '(For non-dynamic objects only.) The function that determines whether or not the player can pass through this object.'
     },
     'object.move': {
         'name': 'object.move(direction)',


### PR DESCRIPTION
When experimenting I realized that dynamic objects cannot be declared impassable (for the player) or passable (for other dynamic objects). The Documentation should reflect this (or the behavior changed while maintaining backwards compability).
