### PR TITLE
Corrected overlapping panes

### DIFF
--- a/styles/game.css
+++ b/styles/game.css
@@ -76,7 +76,7 @@ body {
 #editorPane {
 	position: absolute;
 	top: 0;
-	left: 602px;
+	left: 652px;
 }
 
 #editorPane #editor {


### PR DESCRIPTION
The editorPane was covering part of the screenPane, so the offending CSS was corrected.
