### PR TITLE
Dynamic width #editorPane

### DIFF
--- a/styles/game.css
+++ b/styles/game.css
@@ -40,8 +40,6 @@ body {
 
 #inventory {
 	color: white;
-	position: absolute;
-	top: 505px;
 	font-size: 13px;
 	cursor: default;
 }


### PR DESCRIPTION
Changed the positioning of elements to accommodate the #editorPane being rendered to different widths in different browsers without overlapping or gaps.

Before:
![image](https://cloud.githubusercontent.com/assets/4296045/3556992/7dbb63ea-092a-11e4-835a-7f3b373716aa.png)

After:
![image](https://cloud.githubusercontent.com/assets/4296045/3556997/877659bc-092a-11e4-91ea-277cfd88eaeb.png)
