### PR TITLE
Fix chapter div width

### DIFF
--- a/styles/game.css
+++ b/styles/game.css
@@ -55,7 +55,7 @@ body {
 	display: none;
 	position: absolute;
 	top: 220px;
-	width: 100%;
+	width: 604px;
 	padding: 10px 0;
 	background-color: white;
 	color: black;


### PR DESCRIPTION
When `#editorPane` is displayed then the half of `#chapter` element was overlapped under `#editorPane` because of `width=100%`.

Set its width to absolute value 600 (canvas width) + 2 + 2 (canvas left and right paddings) = 604px.
Absolute values are acceptable here due to `canvas` size is also absolute.

![wrong-chapter-div-width](https://cloud.githubusercontent.com/assets/598919/4827694/771736da-5f7a-11e4-943d-ac141f335f8f.png)
