### PR TITLE
fix issue #331 for level 19

### DIFF
--- a/levels/19_documentObjectMadness.jsx
+++ b/levels/19_documentObjectMadness.jsx
@@ -93,7 +93,11 @@ function startLevel(map) {
         var currentPosition = $dom.find('.' + className);
         if (currentPosition.parent().length > 0) {
             if (currentPosition.parent().hasClass('container')) {
-                map.getPlayer().killedBy('moving off the edge of the DOM');
+                if (className === 'drEval') {
+                    map.getPlayer().killedBy('moving off the edge of the DOM');
+                } else {
+                    return false;
+                }
             } else {
                 currentPosition.parent().addClass(className);
                 currentPosition.removeClass(className);


### PR DESCRIPTION
This pull request implements @mathdude314 's proposed changes, with a little cleanup, to fix `adversary` walking off the DOM and killing Dr. Eval.

It looks like a pull request was never made for this issue so I went ahead and made this one. I haven't tested this and I am just going off of what is mentioned in #331, so proceed with caution.