### PR TITLE
Fuck you Color fix for editable sections

### DIFF
--- a/scripts/codeEditor.js
+++ b/scripts/codeEditor.js
@@ -376,6 +376,7 @@ function CodeEditor(textAreaDomID, width, height, game) {
                     var from = {'line': parseInt(line), 'ch': section[0]};
                     var to = {'line': parseInt(line), 'ch': section[1]};
                     instance.markText(from, to, {'className': 'editableSection'});
+                    instance.addLineClass(parseInt(line), 'wrap', 'partiallyEditable');
                 }
             }
         }

--- a/styles/game.css
+++ b/styles/game.css
@@ -121,9 +121,21 @@ body {
 	background: #511 !important;
 }
 
+.CodeMirror-lines .disabled .CodeMirror-linenumber {
+    background: red;
+    color: black;
+}
+
+.CodeMirror-lines .partiallyEditable .CodeMirror-linenumber {
+    background: rgb(250, 123, 123);
+    color: black;
+}
+
+
 .CodeMirror-lines .disabled .editableSection {
 	background: rgba(0, 0, 0, 0.5); /* semi-transparent so we can see selection over it */
 }
+
 
 #helpPane {
 	position: absolute;


### PR DESCRIPTION
This commit adds a new gutter color for lines that are uneditable and
lines that are partially editable. This should help address issue #84,
although I don't know that it's a full solution because the background
itself isn't changing.