### PR TITLE
Fix issue with size of drawingCanvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 			<span id="nowPlayingMsg" class="topStatus"></span>
 			<span id="savedLevelMsg" class="topStatus"></span>
 			<div id="screenPane">
-				<canvas id="drawingCanvas" width="600" height="500"></canvas>
+				<canvas id="drawingCanvas"></canvas>
 				<div id="dummyDom"></div>
 				<div id="screen"></div>
 				<div id="inventory"></div>

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -352,7 +352,9 @@ function Game(debugMode, startLevel) {
             }
 
             // clear drawing canvas and hide it until level loads
-            $('#drawingCanvas')[0].width = $('#drawingCanvas')[0].width;
+            var screenCanvas = $('#screen canvas')[0];
+            $('#drawingCanvas')[0].width = screenCanvas.width;
+            $('#drawingCanvas')[0].height = screenCanvas.height;
             $('#drawingCanvas').hide();
             $('#dummyDom').hide();
 

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -576,9 +576,10 @@ function Map(display, __game) {
     }, this);
 
     this.getCanvasCoords = wrapExposedMethod(function(obj) {
+        var canvas =  $('#drawingCanvas')[0];
         return {
-            x: (obj.getX() + 0.5) * 600 / __game._dimensions.width,
-            y: (obj.getY() + 0.5) * 500 / __game._dimensions.height
+            x: (obj.getX() + 0.5) * canvas.width / __game._dimensions.width,
+            y: (obj.getY() + 0.5) * canvas.height / __game._dimensions.height
         };
     }, this);
 


### PR DESCRIPTION
Now the drawingCanvas matches the size of the screen canvas. Deals with the canvas alignment issues in levels 16 and 17. Solves #329 (for me at least) on Safari and Chrome.