### PR TITLE
Ensure validation happens even if user code throws error

### DIFF
--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -124,7 +124,9 @@ Game.prototype.validate = function(allCode, playerCode, restartingLevelFromScrip
 // makes sure nothing un-kosher happens during a callback within the game
 // e.g. item collison; function phone
 Game.prototype.validateCallback = function(callback, throwExceptions, ignoreForbiddenCalls) {
-    try {
+    var savedException = null;
+    var exceptionFound = false;
+	try {
         // run the callback and check for forbidden method calls
         try {
             if (!ignoreForbiddenCalls) {
@@ -146,8 +148,9 @@ Game.prototype.validateCallback = function(callback, throwExceptions, ignoreForb
                 // throw e; // for debugging
                 return;
             } else {
-                // other exceptions are fine here - just pass them up
-                throw e;
+                // other exceptions are fine here, but be sure to run validation before passing them up
+                savedException = e;
+                exceptionFound = true;
             }
         }
 
@@ -190,7 +193,9 @@ Game.prototype.validateCallback = function(callback, throwExceptions, ignoreForb
 
                 return;
             }
-
+            if(exceptionFound) {
+            	throw savedException;
+            }
             // refresh the map, just in case
             this.map.refresh();
 

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -126,7 +126,7 @@ Game.prototype.validate = function(allCode, playerCode, restartingLevelFromScrip
 Game.prototype.validateCallback = function(callback, throwExceptions, ignoreForbiddenCalls) {
     var savedException = null;
     var exceptionFound = false;
-	try {
+    try {
         // run the callback and check for forbidden method calls
         try {
             if (!ignoreForbiddenCalls) {


### PR DESCRIPTION
Closes #424. This pull request was made without comment as to whether this is actually a bug or an obscure but intended solution.