### PR TITLE
Forbid `/u` escape sequence

### DIFF
--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -15,7 +15,8 @@ Game.prototype.verbotenWords = [
     'self.', 'self[', 'top.', 'top[', 'frames',  // self === top === frames === window
     'parent', 'content', // parent === content === window in most of cases
     'validate', 'onExit', 'objective', // don't let players rewrite these methods
-    'this[' // prevents this['win'+'dow'], etc.
+    'this[', // prevents this['win'+'dow'], etc.
+     '\\u' // prevents usage of arbitrary code through unicode escape characters, see issue #378
 ];
 Game.prototype.allowedTime = 2000; // for infinite loop prevention
 


### PR DESCRIPTION
This sequence can be used to escape arbitrary code and thus clearly needs to be forbidden.
Closes #378