### PR TITLE
Prevent player from dying prematurely

### DIFF
--- a/scripts/game.js
+++ b/scripts/game.js
@@ -337,6 +337,10 @@ function Game(debugMode, startLevel) {
         // validate the code
         // if it passes validation, returns the startLevel function if it pass
         // if it fails validation, returns false
+        var player = this.map.getPlayer();
+        if(player) {
+            player._allowDeath = false;
+        }
         var validatedStartLevel = this.validate(allCode, playerCode, restartingLevelFromScript);
 
         if (validatedStartLevel) { // code is valid
@@ -399,8 +403,10 @@ function Game(debugMode, startLevel) {
             }
 
             // finally, allow player movement
-            if (this.map.getPlayer()) {
-                this.map.getPlayer()._canMove = true;
+            player = this.map.getPlayer();
+            if (player) {
+                player._canMove = true;
+                player._allowDeath = true;
                 game.display.focus();
             }
         } else { // code is invalid

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -11,6 +11,7 @@ function Player(x, y, __map, __game) {
     /* unexposed variables */
 
     this._canMove = false;
+    this._allowDeath = false;
 
     /* wrapper */
 
@@ -190,6 +191,10 @@ function Player(x, y, __map, __game) {
     }, this);
 
     this.killedBy = wrapExposedMethod(function (killer) {
+        if(!this._allowDeath) {
+            // issue#416 don't restart level during validation/initialization of level to prevent nasty bugs
+            throw 'You have been killed by ' + killer + '!';
+        }
         __game.sound.playSound('hurt');
         __game._restartLevel();
 


### PR DESCRIPTION
Closes #416
If `map.getPlayer().killedBy(reason)` is called during the `startLeve`l function, it causes the level to immediately attempt to restart, causing an infinite loop. For reasons I don't entirely understand, this can confuse the editor about which lines are editable and break the game with "ReferenceError: map is not defined" - but either way it's a bad idea.