### PR TITLE
Throw exceptions even on quickValidate levels

### DIFF
--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -212,6 +212,9 @@ Game.prototype.validateCallback = function(callback, throwExceptions, ignoreForb
 
             return result;
         }
+        if(exceptionFound) {
+            throw savedException;
+        }
     } catch (e) {
         this.map.writeStatus(e.toString());
 


### PR DESCRIPTION
Fixes a bug I introducted #428, which causes the game to not show mid-game exceptions at all in levels with the quickValidate option set (such as level 20).