### PR TITLE
Clear timers after breaking level

### DIFF
--- a/scripts/map.js
+++ b/scripts/map.js
@@ -83,12 +83,7 @@ function Map(display, __game) {
         });
         __dynamicObjects = [];
         __player = null;
-
-        for (var i = 0; i < __intervals.length; i++) {
-            clearInterval(__intervals[i]);
-        }
-        __intervals = [];
-
+        this._clearIntervals();
         __lines = [];
         __dom = '';
         this._overrideKeys = {};
@@ -100,6 +95,13 @@ function Map(display, __game) {
 
         this.finalLevel = false;
         this._callbackValidationFailed = false;
+    };
+    this._clearIntervals = function() {
+        if (__game._isPlayerCodeRunning()) { throw 'Forbidden method call: map._clearIntervals()';}
+        for (var i = 0; i < __intervals.length; i++) {
+            clearInterval(__intervals[i]);
+        }
+        __intervals = [];
     };
 
     this._ready = function () {

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -155,7 +155,7 @@ Game.prototype.validateCallback = function(callback, throwExceptions, ignoreForb
                 this.sound.playSound('static');
                 this.map.getPlayer()._canMove = false;
                 this.map._callbackValidationFailed = true;
-
+                this.map._clearIntervals();
                 // throw e; // for debugging
                 return;
             } else {
@@ -180,7 +180,7 @@ Game.prototype.validateCallback = function(callback, throwExceptions, ignoreForb
             // disable player movement
             this.map.getPlayer()._canMove = false;
             this.map._callbackValidationFailed = true;
-
+            this.map._clearIntervals();
             return;
         }
 
@@ -201,7 +201,7 @@ Game.prototype.validateCallback = function(callback, throwExceptions, ignoreForb
                 // disable player movement
                 this.map.getPlayer()._canMove = false;
                 this.map._callbackValidationFailed = true;
-
+                this.map._clearIntervals();
                 return;
             }
             if(exceptionFound) {


### PR DESCRIPTION
This prevents levels with timers from causing an infinite stream of "Validation failed!" errors. If the timer is not cleared, then it will run, observe that validation still fails, and print another error, which repeats until the level is executed again or a new level starts.

Note that, unlike many of my other patches, this is not a security fix.