### PR TITLE
Rewrite credits level to not depend on private APIs

### DIFF
--- a/levels/22_credits.jsx
+++ b/levels/22_credits.jsx
@@ -1,7 +1,15 @@
 #BEGIN_PROPERTIES#
 {
-    "version": "1.2.1",
-    "music": "Brazil"
+    "version": "1.3.0",
+    "music": "Brazil",
+    "mapProperties": {
+        "showDrawingCanvas": "true"
+    },
+    "commandsIntroduced": [
+            "canvas.fillStyle",
+            "canvas.fillText",
+            "map.timeout"
+    ]
 }
 #END_PROPERTIES#
 /**************
@@ -75,13 +83,11 @@ function startLevel(map) {
         if (i >= credits.length) {
             return;
         }
-
-        // redraw lines bottom to top to avoid cutting off letters
-        for (var j = i; j >= 0; j--) {
-            var line = credits[j];
-            map._display.drawText(line[0], line[1], line[2]);
-        }
-
+        var ctx = map.getCanvasContext();
+        ctx.fillStyle = "#ccc";
+        var line = credits[i];
+        var coords = map.getCanvasCoords(line[0],line[1]);
+        ctx.fillText(line[2],coords.x, coords.y)
         map.timeout(function () {drawCredits(i+1);}, 2000)
     }
 

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -20,7 +20,7 @@ function Game(debugMode, startLevel) {
 //%BONUS%
     ].filter(function (lvl) { return (lvl.indexOf('_') != 0); }); // filter out bonus levels that start with '_'
 
-	this._mod = '//%MOD%';
+    this._mod = '//%MOD%';
 
     this._viewableScripts = [
         'codeEditor.js',
@@ -58,7 +58,7 @@ function Game(debugMode, startLevel) {
 
     this._getHelpCommands = function () { return __commands; };
     this._isPlayerCodeRunning = function () { return __playerCodeRunning; };
-	this._getLocalKey = function (key) { return (this._mod.length == 0 ? '' : this._mod + '.') + key; };
+    this._getLocalKey = function (key) { return (this._mod.length == 0 ? '' : this._mod + '.') + key; };
 
     /* unexposed setters */
 
@@ -314,6 +314,7 @@ function Game(debugMode, startLevel) {
     };
 
     this._evalLevelCode = function (allCode, playerCode, isNewLevel, restartingLevelFromScript) {
+        this.map._clearIntervals();
         var game = this;
 
         // by default, get code from the editor

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -575,14 +575,28 @@ function Map(display, __game) {
     /* canvas-related stuff */
 
     this.getCanvasContext = wrapExposedMethod(function() {
-        return $('#drawingCanvas')[0].getContext('2d');
+        var ctx = $('#drawingCanvas')[0].getContext('2d');
+        if(!this._dummy) {
+            var opts = this._display.getOptions();
+            ctx.font = opts.fontSize+"px " +opts.fontFamily;
+        }
+        return ctx;
     }, this);
 
-    this.getCanvasCoords = wrapExposedMethod(function(obj) {
+    this.getCanvasCoords = wrapExposedMethod(function() {
+        var x, y;
+        if(arguments.length == 1) {
+            var obj = arguments[0];
+            x = obj.getX();
+            y = obj.getY();
+        } else {
+            x = arguments[0];
+            y = arguments[1];
+        }
         var canvas =  $('#drawingCanvas')[0];
         return {
-            x: (obj.getX() + 0.5) * canvas.width / __game._dimensions.width,
-            y: (obj.getY() + 0.5) * canvas.height / __game._dimensions.height
+            x: (x + 0.5) * canvas.width / __game._dimensions.width,
+            y: (y + 0.5) * canvas.height / __game._dimensions.height
         };
     }, this);
 

--- a/scripts/reference.js
+++ b/scripts/reference.js
@@ -35,7 +35,18 @@ Game.prototype.reference = {
         'type': 'property',
         'description': 'Determines the color (and, optionally, other properties) of the next lines drawn.'
     },
-
+    'canvas.fillStyle': {
+        'name': 'canvasContext.fillStyle',
+        'category': 'canvas',
+        'type': 'property',
+        'description': 'Determines the color (and, optionally, other properties) of the text drawn woth <b>fillText</b>.'
+    },
+    'canvas.fillText': {
+        'name': 'canvasContext.fillText(text, x, y)',
+        'category': 'canvas',
+        'type': 'method',
+        'description': 'Draws a given piece of text, starting at specified coordinates, to to the canvas',
+    },
     'global.$': {
         'name': '$(html)',
         'category': 'global',
@@ -183,10 +194,10 @@ Game.prototype.reference = {
         'description': 'Returns the 2D drawing context of the <a onclick="$(\'#helpPaneSidebar .category#canvas\').click();">canvas</a> overlaying the map.'
     },
     'map.getCanvasCoords': {
-        'name': 'map.getCanvasCoords(obj)',
+        'name': 'map.getCanvasCoords(obj) / map.getCanvasCoords(x, y)',
         'category': 'map',
         'type': 'method',
-        'description': 'Returns {"x": x, "y": y}, where x and y are the respective coordinates of the given object on the canvas returned by map.getCanvasContext().'
+        'description': 'Returns {"x": x, "y": y}, where x and y are the respective coordinates of the given object or grid position on the canvas returned by map.getCanvasContext().'
     },
     'map.getDOM': {
         'name': 'map.getDOM()',
@@ -259,6 +270,12 @@ Game.prototype.reference = {
         'category': 'map',
         'type': 'method',
         'description': 'Sets the background color of the given square.'
+    },
+    'map.timeout': {
+        'name': 'map.timeout(callback, delay)',
+        'category': 'map',
+        'type': 'method',
+        'description': 'Starts a timer (c.f. setTimeout) of the given delay, in milliseconds (minimum 25 ms). Unlike map.startTimer, the callback will only run once.'
     },
     'map.startTimer': {
         'name': 'map.startTimer(callback, delay)',

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -76,6 +76,7 @@ Game.prototype.validate = function(allCode, playerCode, restartingLevelFromScrip
         this._endOfStartLevelReached = false;
         dummyMap._reset();
         startLevel(dummyMap);
+        dummyMap._clearIntervals();
 
         // does startLevel() execute fully?
         // (if we're restarting a level after editing a script, we can't test for this


### PR DESCRIPTION
The credits level, as currently coded, depends on the private attribute `map._display`. Access to the display was mostly broken by #433 (display is refreshed as a side effect of validation) and can lead to security issues so, as a predecessor to a future patch that blocks access to internal attributes, this rewrites the credits level
to no longer need that access, and also to work properly.