### PR TITLE
Don't pass game into user code

### DIFF
--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -31,7 +31,7 @@ Game.prototype.removeFromInventory = function (itemName) {
 	this.drawInventory();
 
 	if (object.onDrop) {
-		object.onDrop(this);
+		object.onDrop();
 	}
 };
 

--- a/scripts/objects.js
+++ b/scripts/objects.js
@@ -2,8 +2,8 @@
 Objects can have the following parameters:
     color: '#fff' by default
     impassable: true if it blocks the player from movement (false by default)
-    onCollision: function (player, game) called when player moves over the object
-    onPickUp: function (player, game) called when player picks up the item
+    onCollision: function (player) called when player moves over the object
+    onPickUp: function (player) called when player picks up the item
     symbol: Unicode character representing the object
     type: 'item' or null
 */

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -83,7 +83,7 @@ function Player(x, y, __map, __game) {
                 this._pickUpItem(objectName, objectDef);
             } else if (objectDef.onCollision) {
                 __game.validateCallback(function () {
-                    objectDef.onCollision(player, __game);
+                    objectDef.onCollision(player);
                 }, false, true);
             }
         }


### PR DESCRIPTION
The `game` object has no methods that are intended to be called from level code, and is not used in any `onCollision` or `onDrop` functions in any level. Passing it to `onCollision` and `onDrop` accomplishes nothing other than to create issues like #322.

Closes #322