### PR TITLE
Prevent access to private attributes

### DIFF
--- a/scripts/dynamicObject.js
+++ b/scripts/dynamicObject.js
@@ -237,9 +237,13 @@ function DynamicObject(map, type, x, y, __game) {
         this.target = target;
     }, this);
 
+    // call secureObject to prevent user code from tampering with private attributes
+    __game.secureObject(this, type+".");
+
     // constructor
 
     if (!map._dummy && __definition.interval) {
         this._onTurn();
     }
+
 }

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -111,7 +111,9 @@ function Map(display, __game) {
 
         // set refresh rate if one is specified
         if (__refreshRate) {
-            map.startTimer(function () {
+            // wrapExposedMethod is necessary here to prevent the game from thinking
+            //  `map._status` is an unauthorized attempt to access a private attribute.
+            map.startTimer(wrapExposedMethod(function () {
                 // refresh the map
                 map.refresh();
 
@@ -124,7 +126,7 @@ function Map(display, __game) {
                 if (typeof(__game.objective) === 'function' && __game.objective(map)) {
                     __game._moveToNextLevel();
                 }
-            }, __refreshRate);
+            }), __refreshRate);
         }
     };
 
@@ -695,4 +697,7 @@ function Map(display, __game) {
     /* initialization */
 
     this._reset();
+
+    // call secureObject to prevent user code from tampering with private attributes
+    __game.secureObject(this, "map.");
 }

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -210,5 +210,8 @@ function Player(x, y, __map, __game) {
     this.setPhoneCallback = wrapExposedMethod(function(func) {
         this._phoneFunc = func;
     }, this);
-    
+
+    // call secureObject to prevent user code from tampering with private attributes
+    __game.secureObject(this,"player.");
+
 }


### PR DESCRIPTION
Uses `Object.defineProperty` to prevent user code from attempting to read or write to the values of private attributes.