### PR TITLE
Generalize tamper prevention

### DIFF
--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -277,7 +277,7 @@ Game.prototype.initIframe = function(allowjQuery){
 
 // takes an object and modifies it so that all properties starting with `_`
 // throw an error when accessed in level code,
-// and that certain protected methods are unwritable
+// and that all functions are unwritable
 Game.prototype.secureObject = function(object, objecttype) {
     for (var prop in object) {
         if(prop == "_startOfStartLevelReached" || prop == "_endOfStartLevelReached"){
@@ -286,14 +286,11 @@ Game.prototype.secureObject = function(object, objecttype) {
         }
         if(prop[0] == "_"){
             this.secureProperty(object, prop, objecttype);
-        } else if (!this._superMenuActivated) {
-            var protectedMethods = this.protectedMethods[objecttype];
-            if(protectedMethods && protectedMethods.hasOwnProperty(prop)){
-                Object.defineProperty(object, prop, {
-                        configurable:false,
-                        writable:false
-                });
-            }
+        } else if (!this._superMenuActivated && typeof object[prop] == "function") {
+            Object.defineProperty(object, prop, {
+                    configurable:false,
+                    writable:false
+            });
         }
     }
 }
@@ -335,48 +332,3 @@ Game.prototype.findSyntaxError = function(code, errorMsg) {
     }
     return null;
 };
-Game.prototype.protectedMethods = {
-    'map': {
-        'countObjects': '',
-        'createFromDOM': '',
-        'createFromGrid': '',
-        'displayChapter': '',
-        'defineObject': '',
-        'getAdjacentEmptyCells': '',
-        'getCanvasContext': '',
-        'getCanvasCoords': '',
-        'getDOM': '',
-        'getDynamicObjects': '',
-        'getHeight': '',
-        'getObjectTypeAt': '',
-        'getPlayer': '',
-        'getRandomColor': '',
-        'getWidth': '',
-        'isStartOfLevel': '',
-        'overrideKey': '',
-        'placeObject': '',
-        'placePlayer': '',
-        'setSquareColor': '',
-        'startTimer': '',
-        'updateDOM': '',
-        'validateAtLeastXObjects': '',
-        'validateAtMostXObjects': '',
-        'validateExactlyXManyObjects': '',
-        'validateAtMostXDynamicObjects': '',
-        'validateNoTimers': '',
-        'validateAtLeastXLines': ''
-    },
-    'player': {
-        'atLocation': '',
-        'getColor': '',
-        'getLastMoveDirection': '',
-        'getX': '',
-        'getY': '',
-        'hasItem': '',
-        'killedBy': '',
-        'move': '',
-        'removeItem': '',
-        'setColor': '',
-        'setPhoneCallback': ''
-    }
-}

--- a/solutions/20_bossFight.md
+++ b/solutions/20_bossFight.md
@@ -544,20 +544,3 @@ Touch the '7' to call two bigger bosses that will let you safely pick up the two
     });
     map.placeObject(1, map.getHeight() - 3, 'button');
 ```
-
-## juh9870: Return bullets to sender
-
-Why not just kill boss with his own bullets?
-
-```javascript
-map.overrideKey('down', function(){
-	map.getDynamicObjects().forEach(function(e){
-        var bm = e.move;
-        e.move=function(direction){
-            if(direction=='left'||direction=='right')return;
-            bm('up');
-        };
-    });
-    map.getPlayer().move('down');
-});
-```


### PR DESCRIPTION
Applies the tamper-protection code I wrote in #447 to all functions of all objects instead of just a specified list of map and player functions:

In addition to being cleaner code, many of these methods are called by the game when `_playerCodeRunning` is false, meaning that any tampering with such a method will end up called without the game thinking player code is running, which is a bad idea for obvious reasons. 