### PR TITLE
Fix several places where user code is called insecurely

### DIFF
--- a/scripts/dynamicObject.js
+++ b/scripts/dynamicObject.js
@@ -94,8 +94,9 @@ function DynamicObject(map, type, x, y, __game) {
                     // projectiles automatically kill
                     map.getPlayer().killedBy('a ' + __type);
                 } else {
+                    var thing = this;
                     map._validateCallback(function () {
-                        __definition.onCollision(map.getPlayer(), this);
+                        __definition.onCollision(map.getPlayer(), thing);
                     });
                 }
             }
@@ -118,7 +119,9 @@ function DynamicObject(map, type, x, y, __game) {
             // this part is used by janosgyerik's bonus levels
             if (object.deactivatedBy && object.deactivatedBy.indexOf(__type) > -1) {
                 if (typeof(object.onDeactivate) === 'function') {
-                    object.onDeactivate();
+                    __game.validateCallback(function(){
+                            object.onDeactivate();
+                    });
                 }
                 map._removeItemFromMap(__x, __y, objectName);
             }
@@ -187,7 +190,10 @@ function DynamicObject(map, type, x, y, __game) {
                 // projectiles automatically kill
                 map.getPlayer().killedBy('a ' + __type);
             } else {
-                __definition.onCollision(map.getPlayer(), this);
+                var thing = this;
+                map._validateCallback(function() {
+                    __definition.onCollision(map.getPlayer(), thing);
+                });
             }
         } else if (map._canMoveTo(dest.x, dest.y, __type) &&
                 !map._isPointOccupiedByDynamicObject(dest.x, dest.y)) {

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -145,9 +145,15 @@ function Game(debugMode, startLevel) {
 
     this._moveToNextLevel = function () {
         // is the player permitted to exit?
-        if (typeof this.onExit === 'function' && !this.onExit(this.map)) {
-            this.sound.playSound('blip');
-            return;
+        if (typeof this.onExit === 'function') {
+            var game = this;
+            var canExit = this.validateCallback(function () {
+                    return game.onExit(game.map);
+            });
+            if (!canExit) {
+                this.sound.playSound('blip');
+                return;
+            }
         }
 
         this.sound.playSound('complete');
@@ -418,4 +424,15 @@ function Game(debugMode, startLevel) {
             return f();
         }
     };
+    this._checkObjective = function() {
+        if (typeof(this.objective) === 'function') {
+            var game = this;
+            var objectiveIsMet = this.validateCallback(function() {
+                return game.objective(game.map);
+            });
+            if (objectiveIsMet) {
+                this._moveToNextLevel();
+            }
+        }
+    }
 }

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -31,7 +31,13 @@ Game.prototype.removeFromInventory = function (itemName) {
 	this.drawInventory();
 
 	if (object.onDrop) {
-		object.onDrop();
+		this._setPlayerCodeRunning(true);
+		try {
+			object.onDrop();
+		} catch (e) {
+			this.map.writeStatus(e.toString())
+		}
+		this._setPlayerCodeRunning(false);
 	}
 };
 

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -123,9 +123,7 @@ function Map(display, __game) {
                 this.refresh();
 
                 // check for nonstandard victory condition
-                if (typeof(__game.objective) === 'function' && __game.objective(map)) {
-                    __game._moveToNextLevel();
-                }
+                 __game._checkObjective()
             }, this), __refreshRate);
         }
     };
@@ -619,7 +617,9 @@ function Map(display, __game) {
             if (pDistance(playerCoords.x, playerCoords.y,
                     line.start[0], line.start[1],
                     line.end[0], line.end[1]) < threshold) {
-                line.callback(__player);
+                __game.validateCallback(function() {
+                        line.callback(__player);
+                });
             }
         })
     }, this);

--- a/scripts/objects.js
+++ b/scripts/objects.js
@@ -90,7 +90,9 @@ Game.prototype.getListOfObjects = function () {
             'color': '#0ff',
             'onCollision': function (player) {
                 if (!game.map.finalLevel) {
-                    game._moveToNextLevel();
+                    game._callUnexposedMethod(function () {
+                        game._moveToNextLevel();
+                    });
                 }
             }
         },

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -84,16 +84,17 @@ function Player(x, y, __map, __game) {
             } else if (objectDef.onCollision) {
                 __game.validateCallback(function () {
                     objectDef.onCollision(player);
-                }, false, true);
+                });
             }
         }
 
         // check for collision with any lines on the map
         __map.testLineCollisions(this);
 
-        // check for nonstandard victory condition (e.g. DOM level)
-        if (typeof(__game.objective) === 'function' && __game.objective(__map)) {
-            __game._moveToNextLevel();
+        // don't run checkObjective if validation has already failed to prevent duplicate `Validation failed` errors
+        if (!__map._callbackValidationFailed) {
+            // check for nonstandard victory condition (e.g. DOM level)
+            __game._checkObjective()
         }
     };
 
@@ -109,12 +110,7 @@ function Player(x, y, __map, __game) {
 
         if (object.onPickUp) {
             __game.validateCallback(function () {
-                setTimeout(function () {
-                    object.onPickUp(player);
-                }, 100);
-                // timeout is so that written text is not immediately overwritten
-                // TODO: play around with Display.writeStatus so that this is
-                // not necessary
+                object.onPickUp(player);
             });
         }
     };

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -95,7 +95,9 @@ Game.prototype.validate = function(allCode, playerCode, restartingLevelFromScrip
         // does validateLevel() succeed?
         if (typeof(userCode.validateLevel) === "function") {
             this.validateLevel = userCode.validateLevel;
+            this._setPlayerCodeRunning(true);
             userCode.validateLevel(dummyMap);
+            this._setPlayerCodeRunning(false);
         }
 
         this.onExit = function () { return true; };
@@ -129,15 +131,13 @@ Game.prototype.validate = function(allCode, playerCode, restartingLevelFromScrip
 
 // makes sure nothing un-kosher happens during a callback within the game
 // e.g. item collison; function phone
-Game.prototype.validateCallback = function(callback, throwExceptions, ignoreForbiddenCalls) {
+Game.prototype.validateCallback = function(callback, throwExceptions) {
     var savedException = null;
     var exceptionFound = false;
     try {
         // run the callback and check for forbidden method calls
         try {
-            if (!ignoreForbiddenCalls) {
-                this._setPlayerCodeRunning(true);
-            }
+            this._setPlayerCodeRunning(true);
             var result = callback();
             this._setPlayerCodeRunning(false);
         } catch (e) {
@@ -165,9 +165,12 @@ Game.prototype.validateCallback = function(callback, throwExceptions, ignoreForb
         // check if validator still passes
         try {
             if (typeof(this.validateLevel) === 'function') {
+                this._setPlayerCodeRunning(true);
                 this.validateLevel(this.map);
+                this._setPlayerCodeRunning(false);
             }
         } catch (e) {
+            this._setPlayerCodeRunning(false);
             // validation failed - not much to do here but restart the level, unfortunately
             this.display.appendError(e.toString(), "%c{red}Validation failed! Please reload the level.");
 


### PR DESCRIPTION
Specifically:

1.  The `onDeactivate` method of traps.
2. The `onCollision` method of dynamic objects that have just moved into the player (the player moving into the object was always called securely)
3. `validateLevel`, `onExit`, and `objective`.
4.  the `onDrop` and `onPickUp` methods of items
5.  the `onCollision` method of static objects