### PR TITLE
Fix error when eye would kill player in bonus levels

### DIFF
--- a/scripts/objects.js
+++ b/scripts/objects.js
@@ -60,13 +60,13 @@ function followAndKeepDistance(obj, type) {
 }
 
 // used by bonus levels 01 through 04
-function killPlayerIfTooFar(obj) {
+function killPlayerIfTooFar(obj, map) {
     var target = obj.findNearest('player');
     var leftDist = obj.getX() - target.x;
     var upDist = obj.getY() - target.y;
 
     if (Math.abs(upDist) > 8 || Math.abs(leftDist) > 8) {
-        obj._map.getPlayer().killedBy('"suspicious circumstances"');
+        map.getPlayer().killedBy('"suspicious circumstances"');
     }
 }
 
@@ -228,7 +228,7 @@ Game.prototype.getListOfObjects = function () {
             'color': 'red',
             'behavior': function (me) {
                 followAndKeepDistance(me, 'player');
-                killPlayerIfTooFar(me);
+                killPlayerIfTooFar(me, game.map);
             },
             'onCollision': function (player) {
                 player.killedBy('"the eye"');


### PR DESCRIPTION
#444 means that just calling `obj._map`, which the previous code was doing, will crash with "Attempt to access private property eye._map". Rewrite the code to pass the map explicitly to avoid that error.