### PR TITLE
Fix validation of timers in boss fight level

### DIFF
--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -73,7 +73,6 @@ Game.prototype.validate = function(allCode, playerCode, restartingLevelFromScrip
         this._setPlayerCodeRunning(true);
         userCode.startLevel(dummyMap);
         this._setPlayerCodeRunning(false);
-        dummyMap._clearIntervals();
 
         // does startLevel() execute fully?
         // (if we're restarting a level after editing a script, we can't test for this
@@ -103,6 +102,7 @@ Game.prototype.validate = function(allCode, playerCode, restartingLevelFromScrip
             userCode.validateLevel(dummyMap);
             this._setPlayerCodeRunning(false);
         }
+        dummyMap._clearIntervals();
 
         this.onExit = function () { return true; };
         if (typeof userCode.onExit === "function") {
@@ -118,6 +118,9 @@ Game.prototype.validate = function(allCode, playerCode, restartingLevelFromScrip
     } catch (e) {
         // cleanup
         this._setPlayerCodeRunning(false);
+        if (dummyMap) {
+            dummyMap._clearIntervals();
+        }
 
         var exceptionText = e.toString();
         if (e instanceof SyntaxError) {


### PR DESCRIPTION
The `dummyMap._clearIntervals` call being moved here is necessary to prevent timers from firing at unwanted times, but it has the side effect of meaning that `validateNoTimers`, when run at the start of the level, does nothing. This PR fixes that bug by moving the `clearIntervals` call to be after validation, allowing validation to detect the number of timers properly.