### PR TITLE
Fix bizzare bug involving dying after editing script files

### DIFF
--- a/scripts/game.js
+++ b/scripts/game.js
@@ -332,6 +332,7 @@ function Game(debugMode, startLevel) {
 
         // if we're editing a script file, do something completely different
         if (this._currentFile !== null && !restartingLevelFromScript) {
+            __currentCode = allCode;
             this.validateAndRunScript(allCode);
             return;
         }
@@ -352,7 +353,9 @@ function Game(debugMode, startLevel) {
             this.map._setProperties(this.editor.getProperties()['mapProperties']);
 
             // save editor state
-            __currentCode = allCode;
+            if (!restartingLevelFromScript) {
+                __currentCode = allCode;
+            }
             if (loadedFromEditor && !restartingLevelFromScript) {
                 this.editor.saveGoodState();
             }


### PR DESCRIPTION
To explain the bug in detail: If you edit a script file, and then run the level and die, the game reloads the code from the level into the editor, while still thinking you are editing a script file.