### PR TITLE
Cleanup eval handling

### DIFF
--- a/scripts/game.js
+++ b/scripts/game.js
@@ -51,7 +51,6 @@ function Game(debugMode, startLevel) {
     this._levelReached = 1;
     this._displayedChapters = [];
 
-    this._eval = window.eval; // store our own copy of eval so that we can override window.eval
     this._playerPrototype = Player; // to allow messing with map.js and player.js later
 
     /* unexposed getters */

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -256,7 +256,9 @@ Game.prototype.initIframe = function(allowjQuery){
     // reset any state in the iframe
     iframe.src = "about:blank";
     var iframewindow = iframe.contentWindow;
-    this._eval = iframewindow.eval;
+    if (iframewindow.eval) {
+        this._eval = iframewindow.eval;
+    }
     // delete any unwated global variables in the iframe
     function purgeObject(object) {
         var globals = Object.getOwnPropertyNames(object);


### PR DESCRIPTION
This fixes "TypeError: this._eval is not a function", which would
sometimes occur when running a level. It also removes some redundant
code in scripts/game.js that sets `_eval` at level load that predates
using an iframe.