### PR TITLE
Fix "level saved" message rendering on top of music

### DIFF
--- a/scripts/game.js
+++ b/scripts/game.js
@@ -374,9 +374,9 @@ function Game(debugMode, startLevel) {
             
             // Add the computer to bonus levels that lack it
             if (this._currentLevel == "bonus" && this.map.countObjects("computer") == 0) {
-            	this.addToInventory("computer")
-            	$('#editorPane').show();
-            	this.editor.refresh();
+                this.addToInventory("computer")
+                $('#editorPane, #savedLevelMsg').show();
+                this.editor.refresh();
             }
 
             // draw the map

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -56,7 +56,7 @@ Game.prototype.setInventoryStateByLevel = function (levelNum) {
 	// repopulate inventory by level
 	if (levelNum > 1) {
 		this.addToInventory('computer');
-		$('#editorPane').fadeIn();
+		$('#editorPane, #savedLevelMsg').fadeIn();
 		this.editor.refresh();
 	}
 	if (levelNum > 7) {

--- a/scripts/objects.js
+++ b/scripts/objects.js
@@ -154,12 +154,12 @@ Game.prototype.getListOfObjects = function () {
             'symbol': String.fromCharCode(0x2318), // ⌘
             'color': '#ccc',
             'onPickUp': function (player) {
-                $('#editorPane').fadeIn();
+                $('#editorPane, #savedLevelMsg').fadeIn();
                 game.editor.refresh();
                 game.map.writeStatus('You have picked up the computer!');
             },
             'onDrop': function () {
-                $('#editorPane').hide();
+                $('#editorPane, #savedLevelMsg').hide();
             }
         },
 


### PR DESCRIPTION
This bug happens when you complete a level, and then switched to either level 1 or a bonus level that explicitly places the computer on the map. The "level saved" message appears on top of the name of the music, rendering both pieces of text unreadable.