### PR TITLE
Add support for chains of bonus levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ jsx files are like regular JavaScript files, but have some additional syntax:
   - `music`: name of the background track for the level (see `sound.js`)
   - `startingMessage`: message displayed at the bottom of the screen when the level starts (if any)
   - `version`: increase the level version whenever you update a level
+  - `nextBonusLevel`: load another level automatically when this one is solved
 - `#START_OF_START_LEVEL#` and `#END_OF_START_LEVEL#` should be the first and last line of the `startLevel` method, respectively
 
 #### Adding music

--- a/levels/bonus/01_inTheDesert.jsx
+++ b/levels/bonus/01_inTheDesert.jsx
@@ -1,7 +1,8 @@
 #BEGIN_PROPERTIES#
 {
-    "version": "1.0",
-    "commandsIntroduced": []
+    "version": "1.0.1",
+    "commandsIntroduced": [],
+    "nextBonusLevel": "02_theEmptyRoom.jsx"
 }
 #END_PROPERTIES#
 /******************

--- a/levels/bonus/02_theEmptyRoom.jsx
+++ b/levels/bonus/02_theEmptyRoom.jsx
@@ -1,7 +1,8 @@
 #BEGIN_PROPERTIES#
 {
-    "version": "1.0",
-    "commandsIntroduced": []
+    "version": "1.0.1",
+    "commandsIntroduced": [],
+    "nextBonusLevel": "03_theCollapsingRoom.jsx"
 }
 #END_PROPERTIES#
 /*******************

--- a/levels/bonus/03_theCollapsingRoom.jsx
+++ b/levels/bonus/03_theCollapsingRoom.jsx
@@ -1,7 +1,8 @@
 #BEGIN_PROPERTIES#
 {
-    "version": "0.1",
-    "commandsIntroduced": []
+    "version": "0.1.1",
+    "commandsIntroduced": [],
+    "nextBonusLevel": "04_theGuard.jsx"
 }
 #END_PROPERTIES#
 /************************

--- a/levels/bonus/04_theGuard.jsx
+++ b/levels/bonus/04_theGuard.jsx
@@ -1,7 +1,8 @@
 #BEGIN_PROPERTIES#
 {
-    "version": "0.1",
-    "commandsIntroduced": []
+    "version": "0.1.1",
+    "commandsIntroduced": [],
+    "nextBonusLevel": "05_theCorridor.jsx"
 }
 #END_PROPERTIES#
 /******************

--- a/levels/bonus/AB_1_ANewJourney.jsx
+++ b/levels/bonus/AB_1_ANewJourney.jsx
@@ -1,9 +1,10 @@
 #BEGIN_PROPERTIES#
 {
-    "version": "1.0",
+    "version": "1.0.1",
 	"mapProperties": {
         "allowOverwrite": true
-    }
+    },
+    "nextBonusLevel": "AB_2_FrozenCave.jsx"
 }
 #END_PROPERTIES#
 /***************************

--- a/levels/bonus/AB_2_FrozenCave.jsx
+++ b/levels/bonus/AB_2_FrozenCave.jsx
@@ -1,9 +1,10 @@
 #BEGIN_PROPERTIES#
 {
-    "version": "1.0.1",
+    "version": "1.0.2",
     "mapProperties": {
         "allowOverwrite": true
-    }	
+    },
+    "nextBonusLevel": "AB_3_BoulderMadness.jsx"
 }
 #END_PROPERTIES#
 /**************************

--- a/levels/bonus/AB_3_BoulderMadness.jsx
+++ b/levels/bonus/AB_3_BoulderMadness.jsx
@@ -1,6 +1,7 @@
 #BEGIN_PROPERTIES#
 {
     "version": "1.0.1",
+    "nextBonusLevel": "AB_4_BatAttack.jsx"
 }
 #END_PROPERTIES#
 /********************************

--- a/levels/bonus/AB_4_BatAttack.jsx
+++ b/levels/bonus/AB_4_BatAttack.jsx
@@ -4,6 +4,7 @@
     "commandsIntroduced":
         ["object.passableFor",
          "map.validateExactlyXManyObjects"],
+    "nextBonusLevel": "AB_5_PathOfDoom.jsx"
 }
 #END_PROPERTIES#
 /****************************

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -53,6 +53,8 @@ function Game(debugMode, startLevel) {
 
     this._playerPrototype = Player; // to allow messing with map.js and player.js later
 
+    this._nextBonusLevel = null;
+
     /* unexposed getters */
 
     this._getHelpCommands = function () { return __commands; };
@@ -161,9 +163,13 @@ function Game(debugMode, startLevel) {
         this.map.getPlayer()._canMove = false;
 
         if (this._currentLevel == 'bonus') {
-            // open main menu
-            $('#helpPane, #notepadPane').hide();
-            $('#menuPane').show();
+            if (this._nextBonusLevel) {
+                this._getLevelByPath("levels/bonus/" + this._nextBonusLevel);
+            } else {
+                // open main menu
+                $('#helpPane, #notepadPane').hide();
+                $('#menuPane').show();
+            }
         } else {
             this._getLevel(this._currentLevel + 1, false, true);
         }
@@ -249,6 +255,9 @@ function Game(debugMode, startLevel) {
 
             // load level code in editor
             editor.loadCode(lvlCode);
+
+            // save next bonus level
+            game._nextBonusLevel = editor.getProperties()["nextBonusLevel"];
 
             // start the level and fade in
             game._evalLevelCode(null, null, true);


### PR DESCRIPTION
When one level in the chain is solved, the next level is automatically loaded. This does not prevent the player from loading later levels
manually.