### PR TITLE
prevent undefined objects

### DIFF
--- a/levels/bonus/02_theEmptyRoom.jsx
+++ b/levels/bonus/02_theEmptyRoom.jsx
@@ -45,6 +45,9 @@ function startLevel(map) {
             if (!challenge()) {
                 player.killedBy('wrong answer');
             }
+            if (getAnswer(input) == undefined) {
+                player.killedBy('unanswered');
+            }
             if (!map.opened) {
                 map.writeStatus("*click*");
                 map.opened = true;


### PR DESCRIPTION
If I return an undefined variable I won't die when I collide with the terminal.  I've added an additional test on lines 48-50 to prevent this.