### PR TITLE
Add another solution to levelName.md

### DIFF
--- a/solutions/bonus/levelName.md
+++ b/solutions/bonus/levelName.md
@@ -4,3 +4,10 @@ Replace the setColor() function of the player and then the door won't be able to
 ```javascript
 map.getPlayer().setColor = function(){}
 ```
+## Pppery: ... or you can but I can change it back:
+```
+map.overrideKey("down",function() {
+    map.getPlayer().move("down");
+    map.getPlayer().setColor("#0f0");
+});
+```


### PR DESCRIPTION
Because the only listed solution to a level being tampering of the sort that would have been prohibited before the super menu was unlocked gives the impression that the level is impossible without cheating.

(I wonder whether I should enable tamper checking in bonus levels, then, given that I suspect @kedilayanaveen10 didn't realize this)