### PR TITLE
Fix death workflow

### DIFF
--- a/scripts/player.js
+++ b/scripts/player.js
@@ -189,8 +189,14 @@ function Player(x, y, __map, __game) {
     }, this);
 
     this.killedBy = wrapExposedMethod(function (killer) {
+        if (__map._dummy) {
+            // Treat player death during StartLevel the same way as a validation failure to avoid nasty infinite loops
+            throw "You have been killed by \n" + killer;
+        }
         __game.sound.playSound('hurt');
-        __game._restartLevel();
+        setTimeout(function() {
+            __game._restartLevel();
+        }, 0);
 
         __map.displayChapter('You have been killed by \n' + killer + '!', 'death');
     }, this);


### PR DESCRIPTION
Fixes #159, and also an unreported bug where dying in some levels (such as level 10) would produce a bogus error message to the console upon reload.