### PR TITLE
Revert "prevent undefined objects"

### DIFF
--- a/levels/bonus/02_theEmptyRoom.jsx
+++ b/levels/bonus/02_theEmptyRoom.jsx
@@ -45,9 +45,6 @@ function startLevel(map) {
             if (!challenge()) {
                 player.killedBy('wrong answer');
             }
-            if (getAnswer(input) == undefined) {
-                player.killedBy('unanswered');
-            }
             if (!map.opened) {
                 map.writeStatus("*click*");
                 map.opened = true;


### PR DESCRIPTION
Reverts AlexNisnevich/untrusted#471

To fix #514

And because this was added by a later user not the original author of the level whereas the spirit of the game says it's up to the level author(s) to deal with unintended solutions.